### PR TITLE
merge function for mergesort

### DIFF
--- a/Code/merge.idr
+++ b/Code/merge.idr
@@ -1,0 +1,33 @@
+module Mergesort
+
+import Data.Vect
+
+
+Vecttake : (m:Nat)->Vect n elem->Vect m  elem
+Vecttake Z xs = []
+Vecttake (S k) (x::xs) = x::(Vecttake k xs)
+
+Vecttakefromlast :(m:Nat)->Vect n elem ->Vect m elem
+Vecttakefromlast m xs = reverse (Vecttake  m (reverse xs))
+
+
+
+
+
+
+merge1 :Ord elem =>Vect  n elem ->Vect  m elem ->Vect (n+m) elem
+merge1 [] ys = ys
+merge1  (x :: xs) [] =  (x::xs)++[]
+merge1 (x :: xs) (y :: ys) = case x<=y of
+                                 False => y:: (merge1 xs (x::ys))
+                                 True => x::(merge1 xs (y::ys))
+{-
+
+mergesort :Ord elem=>Vect n elem->Vect n elem
+mergesort []=[]
+mergesort [x] = [x]
+mergesort {n} xs = (the (Vect n elem ) (merge left right)) where
+  left = Vecttake s xs
+  right = Vecttake (cast ((cast n)-(cast s))) xs where
+    s =cast((cast n)/2)
+    -}

--- a/Code/merge.idr
+++ b/Code/merge.idr
@@ -27,7 +27,7 @@ mergesort :Ord elem=>Vect n elem->Vect n elem
 mergesort []=[]
 mergesort [x] = [x]
 mergesort {n} xs = (the (Vect n elem ) (merge left right)) where
-  left = Vecttake s xs
-  right = Vecttake (cast ((cast n)-(cast s))) xs where
+  left = mergesort (Vecttake s xs)
+  right = mergesort (Vecttake (cast ((cast n)-(cast s))) xs) where
     s =cast((cast n)/2)
     -}


### PR DESCRIPTION
I implemented the merge function required for mergesort. I had to change it a little so that the types matched. You will see that i had to transfer x from one vector to the other in one case . I tried to implement mergesort. The code is given as comment. But it doesnt work (I think it is because it cant recognise that (n-s)+s =n )