### PR TITLE
Given a definition of the required SortedVect type

### DIFF
--- a/Code/Finite.idr
+++ b/Code/Finite.idr
@@ -1,0 +1,36 @@
+module Finite.idr
+
+import Data.Fin
+
+--- This is the module for the Finite sets
+
+||| The Data type finite. It is the same as Fin except the size has been made explicit
+data Finite : Nat -> Type where
+    FinZ : (k : Nat) -> (Finite (S k))
+    FinS : (k : Nat) -> (Finite k) -> (Finite (S k)) 
+
+total
+Finite_to_Fin : (k : Nat) -> (Finite k) -> (Fin k)
+Finite_to_Fin Z a impossible
+Finite_to_Fin (S k) (FinZ k) = FZ
+Finite_to_Fin (S k) (FinS k nm) = FS (Finite_to_Fin k nm) 
+
+total 
+Fin_to_Finite : (k : Nat) -> (Fin k) -> (Finite k)
+Fin_to_Finite Z a impossible
+Fin_to_Finite (S k) FZ = FinZ k
+Fin_to_Finite (S k) (FS l) = FinS k (Fin_to_Finite k l)
+
+||| Predecessor function for finite
+total
+predFinite : (k : Nat) -> (Finite k) -> (Finite k)
+predFinite Z a impossible
+predFinite (S k) (FinZ k) = FinZ k
+predFinite (S (S k)) (FinS (S k) (FinZ k)) = FinZ (S k)
+predFinite (S (S k)) (FinS (S k) l) = FinS (S k) (predFinite (S k) l)
+
+||| Predecessor function for fin
+total
+predFin : (n : Nat) -> (Fin n) -> (Fin n)
+predFin n a = Finite_to_Fin n ( predFinite n (Fin_to_Finite n a))
+

--- a/Code/Group.idr
+++ b/Code/Group.idr
@@ -1,0 +1,31 @@
+module Group
+
+%access public export
+
+||| Given a type and a binary operation the type of proofs that the operation is associative
+total
+Associative : (typ : Type) -> (op : typ -> typ -> typ) -> Type 
+Associative typ op = (a : typ) -> (b : typ) -> (c : typ) -> ((op (op a b) c) = (op a (op b c)))
+
+||| Given a type and a binary operation the type of proofs that the operation is commutative
+total
+Commutative : (typ : Type) -> (op : typ -> typ -> typ) -> Type
+Commutative typ op = (a : typ) -> (b : typ) -> ((op a b) = (op b a))
+
+||| Given a type and a binary operation the type of proofs that identity exists
+total
+IdentityExists : (typ : Type) -> (op : typ -> typ -> typ) -> Type
+IdentityExists typ op = ( e : typ ** (a : typ ** (( (op a e) = a), (op e a) = a))) 
+
+||| Given a type and a binary operation the type of proofs that each element has its inverse
+total
+InverseExists : (typ : Type) -> (op : typ -> typ -> typ) -> Type
+InverseExists typ op = (pfIden : (IdentityExists typ op) ** ((a : typ) -> (a_inv : typ ** 
+                       (((op a a_inv) = (fst pfIden)), 
+                       ((op a_inv a) = (fst pfIden))))))   
+
+||| Given a type and a binary operation the type of proofs that the type along with the
+||| operation is a group
+total
+IsGroup : (grp : Type) -> (op : grp -> grp -> grp) -> Type
+IsGroup grp op = (Associative grp op, (IdentityExists grp op, InverseExists grp op))

--- a/Code/perm_cons.idr
+++ b/Code/perm_cons.idr
@@ -1,0 +1,22 @@
+module permutation_with_constructors
+
+import Data.Vect
+
+%access public export
+
+--- Goal - To define permutations with constructors
+
+data PermC : Nat -> Type where
+    Idt : (n : Nat) -> PermC n -- Identity permutation
+    Flip : (n : Nat) -> PermC n -- [1 2 3 ... n]-> [2 1 3 ... n]
+    Shift : (n : Nat) -> PermC n -- [1 2 3 .. n] -> [n 1 2 .. (n-1)]
+    CPerm : (n : Nat) -> PermC n -> PermC n -> PermC n
+    
+total    
+applyPerm : (n : Nat) -> (t : Type) -> (PermC n) -> (Vect n t) -> (Vect n t)
+applyPerm Z typ p v = v
+applyPerm (S Z) typ p v = v
+applyPerm n typ (Idt n) v = v
+applyPerm (S (S k)) t (Flip (S (S k))) v = (index (FS FZ) v) :: ( (index FZ v) :: (tail(tail v)))
+applyPerm (S (S k)) t (Shift (S (S k))) v = reverse( (index FZ v) :: (reverse (tail v)))
+applyPerm n t (CPerm n f g) v = applyPerm n t f (applyPerm n t g v)

--- a/Code/permutation.idr
+++ b/Code/permutation.idr
@@ -1,0 +1,59 @@
+module permutation
+
+import Data.Vect
+import Data.Fin
+
+%access public export
+
+||| Vectors of Natural numbers
+total
+NatVect : Nat -> Type 
+NatVect n = Vect n Nat
+
+||| The type Fin n -> Fin n
+total
+F_Fin : Nat -> Type
+F_Fin n = (Fin n) -> (Fin n) 
+
+||| Identity function
+total
+Idt : (t : Type) -> t -> t
+Idt s a = a
+
+||| The type of permutation/bijection of {1,...,n}. 
+||| Notice that for finite sets one sided inverse is enough. 
+||| Also I have a strong feeling that using univalence the last part of the definition is 
+||| equivalent to saying that (g . f) and Idt are equivalent
+total
+PermB : Nat -> Type
+PermB n = ( f : F_Fin n ** ( g : F_Fin n ** ((a : (Fin n)) -> ((g (f a)) = a))))
+
+||| Second definition of perm. I have strong feeling that using univalence this is equivalent
+||| to the first definition.
+total
+Perm2 : Nat -> Type
+Perm2 n = ( f : F_Fin n ** ( g : F_Fin n ** ((g . f) = (Idt (Fin n)))))
+
+||| Nat to Fin
+total
+NatToFin : (k : Nat) -> (n : Nat) -> (pf : LTE (S k) n) -> (Fin n)
+NatToFin k Z pf impossible
+NatToFin Z (S n) pf = FZ
+NatToFin (S k) (S n) (LTESucc pf) = FS (NatToFin k n pf)
+
+||| applying a function on Finite sets on a vector
+total
+applyFun : (n : Nat)  -> (k : Nat) -> (v : NatVect n) -> 
+           (f : F_Fin n) -> (pf : (LTE k n))
+            -> (NatVect k)
+
+applyFun n Z v f pf = []
+applyFun n (S k) v f pf = reverse((Vect.index (f (NatToFin k n pf)) v) :: reverse((applyFun n k v f (prop k n pf)))) where
+    prop : (a : Nat) -> (b : Nat) -> (LTE (S a) b) -> (LTE a b)
+    prop Z b pf2 = LTEZero
+    prop (S a) (S b) (LTESucc pf2) = LTESucc (prop a b pf2)
+    
+
+
+
+

--- a/Code/sorting_with_proof.idr
+++ b/Code/sorting_with_proof.idr
@@ -2,76 +2,38 @@ module sorting_with_proof
 
 import Data.Vect
 import Data.Fin
+import permutation
+import perm_cons
+import Finite
 
-||| Vectors of Natural numbers
-total
-NatVect : Nat -> Type 
-NatVect n = Vect n Nat
+%access public export
 
-||| The type Fin n -> Fin n
-total
-F_Fin : Nat -> Type
-F_Fin n = (Fin n) -> (Fin n) 
-
-||| Identity function
-total
-Idt : (t : Type) -> t -> t
-Idt s a = a
-
-||| The type of permutation/bijection of {1,...,n}. 
-||| Notice that for finite sets one sided inverse is enough. 
-||| Also I have a strong feeling that using univalence the last part of the definition is 
-||| equivalent to saying that (g . f) and Idt are equivalent
-total
-Perm : Nat -> Type
-Perm n = ( f : F_Fin n ** ( g : F_Fin n ** ((a : (Fin n)) -> ((g (f a)) = a))))
-
-||| Second definition of perm. I have strong feeling that using univalence this is equivalent
-||| to the first definition.
-total
-Perm2 : Nat -> Type
-Perm2 n = ( f : F_Fin n ** ( g : F_Fin n ** ((g . f) = (Idt (Fin n)))))
-
-data Finite : Nat -> Type where
-    FinZ : (k : Nat) -> (Finite (S k))
-    FinS : (k : Nat) -> (Finite k) -> (Finite (S k)) 
-
-total
-Finite_to_Fin : (k : Nat) -> (Finite k) -> (Fin k)
-Finite_to_Fin Z a impossible
-Finite_to_Fin (S k) (FinZ k) = FZ
-Finite_to_Fin (S k) (FinS k nm) = FS (Finite_to_Fin k nm) 
-
-total 
-Fin_to_Finite : (k : Nat) -> (Fin k) -> (Finite k)
-Fin_to_Finite Z a impossible
-Fin_to_Finite (S k) FZ = FinZ k
-Fin_to_Finite (S k) (FS l) = FinS k (Fin_to_Finite k l)
-
-||| Predecessor function for finite
-total
-predFinite : (k : Nat) -> (Finite k) -> (Finite k)
-predFinite Z a impossible
-predFinite (S k) (FinZ k) = FinZ k
-predFinite (S (S k)) (FinS (S k) (FinZ k)) = FinZ (S k)
-predFinite (S (S k)) (FinS (S k) l) = FinS (S k) (predFinite (S k) l)
-
-||| Predecessor function for fin
-total
-predFin : (n : Nat) -> (Fin n) -> (Fin n)
-predFin n a = Finite_to_Fin n ( predFinite n (Fin_to_Finite n a))
-
-||| Type of proofs that a vector is sorted in increasing order. 
-||| Note that the predecessor function takes care of the first index 
+||| Type of proofs that a vector 'v' of length 'n' is sorted in increasing order. 
+||| It takes the following parameters : 'n'(length of the vector), 'v'(vector), 
+||| 'ind'(index). Check if v[ind - 1] <= v[ind]. Note that the predecessor 
+||| function takes care of the first index ( pred FZ = FZ ). 
 total
 SortProof : (n : Nat) -> (NatVect n) -> (Fin n) -> Type 
 SortProof Z v a impossible
 SortProof (S k) v l = LTE (Vect.index (pred l) v) (Vect.index l v)
 
-||| Type of the sorted vectors.
-SortedVect : Type
-SortedVect = (n : Nat ** (v : (NatVect n)  ** ((k : Fin n) -> (SortProof n v k)))) 
+||| If 'v' is a vector of length 'n' then an element of the Type 
+||| (IsSorted n v) is a function which given an index 'k' gives
+||| a proof that v[k-1] <= v[k]. The special case for first
+||| index is taken care of by the predecessor function
+||| (pred FZ = FZ).  
+total
+IsSorted : (n : Nat) -> (v : (NatVect n)) -> Type
+IsSorted n v = (k : Fin n) -> (SortProof n v k)
 
+||| An element of the type SortedVect n v is of the form (v_sorted, perm, pfPerm, pfSort) 
+||| where 'v_sorted' is 'v' with its element sorted in increasing order. 'perm' is a 
+||| permutation such that perm(v) = v_sorted. 'pfPerm' is a proof that perm(v) = v_sorted. 
+||| 'pfSort' is a proof that 'v_sorted' is sorted.
+total 
+SortedVect : (n : Nat) -> (v : (NatVect n)) -> Type
+SortedVect n v = (v_sorted : (NatVect n) ** 
+                 (perm : (PermC n) ** (((applyPerm n Nat perm v) = v_sorted), (IsSorted n v))))
 
 
 


### PR DESCRIPTION
Divided the code into four files
1. Finite.idr - Defined the type Finite n(Finite set of n elements). It is same as the Fin except the 'n' is made explicit
2. perm_cons.idr - Defined permutation with constructors.
3. permutation.idr - Defined permutation as bijections
4. sorting_with_proof - Defined the required SortedVect type
Please check the documentations for explanations.