### PR TITLE
Some fixes to simplifyRational

### DIFF
--- a/Code/Rationals.idr
+++ b/Code/Rationals.idr
@@ -1,11 +1,5 @@
 module Rationals
 
---Type for divisibility
-data isDivisor : Integer -> Integer -> Type where
-  AllDivZ : (m : Integer) -> isDivisor m 0
-  OneDivAll : (m : Integer) -> isDivisor 1 m
-  MulDiv : (c : Integer) -> isDivisor n m -> isDivisor ((\l => l*c) n) ((\l => l*c) m)
-
 isNotZero : Nat -> Bool
 isNotZero Z = False
 isNotZero (S k) = True
@@ -24,16 +18,20 @@ Eucl Z b = (0,0)
 Eucl (S k) b = case (lte (S (S k)) b) of
                     False => (S(fst(Eucl (minus (S k) b) b)), snd(Eucl (minus (S k) b) b))
                     True => (0, S k)
-{-
-gcdab : Nat -> Nat -> Nat -- Produces the GCD of two numbers. This will be useful to produce the simplified form of a rational number.
-gcdab b Z = b
-gcdab a b = gcdab b (snd (Eucl a b))
--}
+
+--Integer implemetation of gcd
+CalcGCD : (Integer, Integer) -> Integer
+CalcGCD (a, b) = if (isNotZero (toNat b)) then next else a where
+    next = CalcGCD (b, toIntegerNat (modNat (toNat a) (toNat b)))
+
+OnlyPositive : (x: Pair) -> Pair
+OnlyPositive x = (if (fst x)>0 then fst x else (-1)*(fst x), if(snd x)>0 then (snd x) else (-1)*(snd x))
 
 --Integer implemetation of gcd
 gccd : (Integer, Integer) -> Integer
-gccd (a, b) = if (isNotZero (toNat b)) then next else a where
-  next = gccd (b, toIntegerNat (modNat (toNat a) (toNat b)))
+gccd x = CalcGCD (OnlyPositive x)
+
+
 
 data NotZero : Integer -> Type where --Proof that a number is not zero, needed to construct Q
   OneNotZero : NotZero 1


### PR DESCRIPTION
I extended the GCD function to negative numbers so that pairs representing negative rationals can be simplified. (calculating the GCD when one number is negative leads to issues with examples such as (3,-6), which is erroneously simplified to (0,1)). I made a minor fix here by forcing the GCD to be a positive number.

An issue related to this project: there were two files which were the predecessor of this one. Somehow they were merged, but some of the history seems to be lost in the history of this file. For reference, here are the previous edits:

https://github.com/SS-C4/LTS2019/commits/c92a54c3a915e40b049eabfa008c3bb482ca878a/Code/Rationals.idr

https://github.com/siddhartha-gadgil/LTS2019/commits/a2b3964a651f0d6dcd75f3985e736392602a7acd/Rationals.idr

-- Abishek (AR-MA210)