### PR TITLE
Gauss-Jordan implemented

### DIFF
--- a/Code/LinearAlgebra.idr
+++ b/Code/LinearAlgebra.idr
@@ -104,3 +104,14 @@ MakeColumnZero n x col (S k) = case (isLTE (S k) col) of
 
 -- The next step here is to use the above function to make a matrix upper triangular. This can be
 -- done by inducting on the number of columns.
+
+-- A helper function, which recursively fills zeros into columns.
+
+UpperTriangularize: (x: Matrix n n ZZPair) -> (iter: Nat) -> Matrix n n ZZPair
+UpperTriangularize {n} x Z = (MakeColumnZero n x Z (Pred n)) -- Column Zero is the base case
+UpperTriangularize {n} x (S k) = (MakeColumnZero n (MakeColumnZero n x k (Pred n)) (S k) (Pred n))
+
+-- Enter a matrix, get the upper triangular form.
+
+UpperTriangularForm: (x: Matrix n n ZZPair) -> Matrix n n ZZPair
+UpperTriangularForm {n} x = UpperTriangularize x (Pred (Pred n))


### PR DESCRIPTION
Using the MakeColumnZero function recursively, I implemented Gauss-Jordan elimination as far as to make a matrix upper triangular.

Caution: Although the algorithm I implemented is correct as far as I know, it will crash if it handles large numerations/fractions (because the analogue of simplifyRational for Matrices has not been added yet). For checking, simple examples will be best until simplification is implemented (soon). 3x3 matrices and smaller work fine, larger ones run into computational issues.

-- Abishek (AR-MA210)