### PR TITLE
Added Fin-based addition for Fin n

### DIFF
--- a/Code/BaseN.idr
+++ b/Code/BaseN.idr
@@ -74,7 +74,7 @@ Predec Z _ Refl impossible
 Predec (S k) FZ Refl = FZ
 Predec (S k) (FS x) prf = FS (Predec k x (IsNotnPf (S k) (FS x) prf))
 
---In spirit the decidable type for Isn
+--A type in some sense resembling the decidable type for truth of Isn (with contra replaced by equality to False)
 DecIsn: (n: Nat) -> (p: (Fin (S n))) -> Either (Isn n p = True) (Isn n p = False)
 DecIsn Z p = Left Refl
 DecIsn (S k) FZ = Right Refl


### PR DESCRIPTION
Used auxiliary proofs for case-work on the sum exceeding n in (Fin (S n))

1) Isn: Checks whether a given (Fin(S n)) is n itself
2) IsnisIsn: Proves the definitional equality for Isn
3) IsNotnPf: Pulls back falsity of Isn (S n) (FS x) to Isn n x
4) Predec: Predecessor function for values not equal to n
5) DecIsn: Somewhat like the decidable type for truth of Isn
6) addfin: the actual addition function