### PR TITLE
Started with decidability of divisibility

### DIFF
--- a/Code/NatUtils.idr
+++ b/Code/NatUtils.idr
@@ -1,9 +1,9 @@
 module Tools.NatUtils
-import ZZ
+--import ZZ
 %access public export
 
 {-small auxillary proofs regarding the equality type-}
-
+{-
 apZZ : (f: ZZ -> ZZ) -> (n: ZZ) -> (m: ZZ) -> n = m -> f n = f m
 apZZ f m m Refl = Refl
 
@@ -18,7 +18,7 @@ equality1 p k a x l b y = addeqns a (p*k) x b (p*l) y
 
 equality2 : (p:ZZ)->(k:ZZ)->(a:ZZ)-> (a=p*k)->(l:ZZ)->(b:ZZ)->(b=p*l)->(a+b)=p*(k+l)
 equality2 p k a x l b y = trans (equality1 p k a x l b y) (sym (multDistributesOverPlusRightZ p k l))
-
+-}
 {-end of auxillary proofs-}
 
 -- Proof of the type that an implication implies its contrapositive

--- a/Code/Primes.idr
+++ b/Code/Primes.idr
@@ -1,7 +1,9 @@
 module Primes
+
 import NatUtils
 
 %access public export
+%default total
 
 --isDivisible a b can be constucted if b divides a
 isDivisible : Nat -> Nat -> Type
@@ -80,20 +82,27 @@ aEqProdImpAGtB (b * (S k)) b (S k) x Refl = case b of
                 rewrite sym (multDistributesOverPlusRight (S k) 1 m) in
                 multRightLTE 1 (S k) (S m) (LTESucc (LTEZero)) x
 
---If a < b, b cannot divide a
---greaterCantDiv : (a : Nat) -> (b : Nat) -> GT b a -> (isDivisible a b -> Void)
+--Not LTE implies GT
+--(this is from a pull request on Idris-lang which was not accepted)
+notLTEImpliesGT : Not (LTE i j) -> GT i j
+notLTEImpliesGT {i = Z}             notLt = absurd $ notLt LTEZero
+notLTEImpliesGT {i = S k} {j = Z}   _     = LTESucc LTEZero
+notLTEImpliesGT {i = S j} {j = S k} notLt = LTESucc (notLTEImpliesGT (notLt . LTESucc))
 
 --Decidability for divisibility
-{-
 decDiv : (p : Nat) -> LTE 2 p -> (x : Nat) -> Dec (isDivisible p x)
+decDiv Z LTEZero _ impossible
+decDiv Z (LTESucc _) _ impossible
+decDiv (S Z) (LTESucc LTEZero) _ impossible
+decDiv (S Z) (LTESucc (LTESucc _)) _ impossible
 decDiv (S (S k)) (LTESucc (LTESucc LTEZero)) x =
-  case totOrdNat (S (S k)) x of
-      (Left l) => Yes ((S Z) ** (rewrite l in
-                                 rewrite sym (multOneRightNeutral x) in
-                                 Refl))
-      (Right (Left l)) => ?dgv_3
-      (Right (Right r)) => No ?dgv_4
--}
+            case totOrdNat (S (S k)) x of
+                (Left l) => Yes (1 ** ((LTESucc LTEZero),
+                                       rewrite l in
+                                       rewrite sym (multOneRightNeutral x) in
+                                       Refl))
+                (Right (Left l)) => No ?e3
+                (Right (Right r)) => ?e4
 
 --Spare code
 {-


### PR DESCRIPTION
Also commented out the offending code in NatUtils as a temporary solution. 
(Help needed : a function `GTImpliesNotLTE` which takes in `GT a b` and returns a type `LTE a b -> Void`. I have a proof for the other direction, from an online source)
@shafilmaheenn is working on fixing it, and it will be returned to it's full functionality soon.