### PR TITLE
 Bezout coefficients with proof for positive and nonnegative integers

### DIFF
--- a/Code/GCDZZ.idr
+++ b/Code/GCDZZ.idr
@@ -31,6 +31,22 @@ GCDCalc (Pos (S j)) (Pos  (S k)) Positive NonNegative =
        (case GCDCalc (Pos (S k)) rem Positive remNonNeg of
              (x ** pf) => (x**(euclidConservesGcdWithProof equality pf)))
 
+|||Returns Bezout coefficients with proof for a Positive integer a and
+|||NonNegative integer b with proofs of GCD and equality
+bez:(a:ZZ)->(b:ZZ)->(IsPositive a)->(IsNonNegative b) ->
+   (d**((GCDZ a b d),(m:ZZ**n:ZZ**(d=(m*a)+(n*b)))))
+bez a (Pos Z) x NonNegative = (a**((gcdOfZeroAndInteger a x),(1**0**prf))) where
+  prf = rewrite (multOneLeftNeutralZ a) in
+     (rewrite  (plusZeroRightNeutralZ a) in Refl)
+bez (Pos (S j)) (Pos  (S k)) Positive NonNegative =
+  case QuotRemZ (Pos (S j)) (Pos  (S k)) NonNegative Positive of
+      (quot ** (rem  ** (equality, remLessb,remNonNeg))) =>
+         (case bez (Pos (S k)) rem Positive remNonNeg of
+            (g**((gcdprf),(m1**n1**lincombproof))) =>
+               (g**((euclidConservesGcdWithProof equality gcdprf),((n1)**(m1+(n1*(-quot)))**(bezoutReplace equality lincombproof)))))
+
+
+
 |||Returns gcd of two integers with proof given that not both of them are zero
 gcdZZ:(a:ZZ)->(b:ZZ)->(NotBothZeroZ a b)->(d**(GCDZ a b d))
 gcdZZ (Pos (S k)) (Pos j) LeftPositive =

--- a/Code/ZZUtils.idr
+++ b/Code/ZZUtils.idr
@@ -136,3 +136,27 @@ multLeftCancelZ left right1 right2 x prf =
     expression = rewrite (multCommutativeZ right1 left) in
                  rewrite (multCommutativeZ right2 left) in
                   prf
+
+
+
+|||The theorem that if  a =r+q*b and g = (m1*b)+(n1*rem)
+|||Then g = (n1*a) + ((m1+n1*(-quot))*b)
+bezoutReplace:{a:ZZ}->{b:ZZ}->{m1:ZZ}->{rem:ZZ}->
+  {quot:ZZ}->{n1:ZZ}->{g:ZZ}-> (a = rem + (quot *b))->
+     (g=(m1*b)+(n1*rem))->(g = (n1*a) + ((m1+n1*(-quot))*b))
+bezoutReplace {a}{b}{m1}{rem}{quot}{n1}{g}prf prf1 =
+  rewrite multDistributesOverPlusLeftZ m1 (n1*(-quot)) b in
+  rewrite prf in
+  rewrite multDistributesOverPlusRightZ n1 rem (quot*b) in
+  rewrite (sym (plusAssociativeZ (n1*rem) (n1*((quot)*b)) ((m1*b)+((n1*(-quot))*b)))) in
+  rewrite (plusCommutativeZ (m1*b) ((n1*(-quot))*b)) in
+  rewrite (plusAssociativeZ (n1*((quot)*b)) ((n1*(-quot))*b) (m1*b)) in
+  rewrite (multAssociativeZ n1 quot b) in
+  rewrite (sym (multDistributesOverPlusLeftZ (n1*quot) (n1*(-quot)) b)) in
+  rewrite (sym(multDistributesOverPlusRightZ n1 quot (-quot))) in
+  rewrite (plusNegateInverseLZ quot) in
+  rewrite (multZeroRightZeroZ n1) in
+  rewrite (multZeroLeftZeroZ b) in
+  rewrite (plusZeroLeftNeutralZ (m1*b)) in
+  rewrite (plusCommutativeZ (n1*rem) (m1*b)) in
+   prf1


### PR DESCRIPTION
The bez function returns the Bezout coefficients with proof that d = gcd (a,b) and d= m*a +n*b
for positive a and nonnegative b.
But I couldn't convince idris that it is total